### PR TITLE
Remove hardcoded path to lnk file

### DIFF
--- a/LinqToLdap.Tests.ClassMapAssembly/LinqToLdap.Tests.ClassMapAssembly.csproj
+++ b/LinqToLdap.Tests.ClassMapAssembly/LinqToLdap.Tests.ClassMapAssembly.csproj
@@ -1,10 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <DelaySign>false</DelaySign>
-    <AssemblyOriginatorKeyFile>C:\Users\alanhatter\Code\github\madhatter\LinqToLdap\LinqToLdap.Tests\linqtoldap_tests.snk</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>..\LinqToLdap.Tests\linqtoldap_tests.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes https://github.com/madhatter22/LinqToLdap/issues/33

(Although I still get test errors. I cannot build LinqToLdap.Tests, only the variants of it. Something with `The "ResolvePackageAssets" task was not given a value for the required parameter "TargetFramework".`)