### PR TITLE
Fix DelegateSpeedTest not running in all localisations

### DIFF
--- a/LinqToLdap.Tests/PerformanceTests/DelegateSpeedTest.cs
+++ b/LinqToLdap.Tests/PerformanceTests/DelegateSpeedTest.cs
@@ -390,7 +390,7 @@ namespace LinqToLdap.Tests.PerformanceTests
             };
             var objectClasses = objectClassesDictionary.Values.ToArray();
             var watch = Stopwatch.StartNew();
-            for (int i = 0; i < int.Parse("100,000", NumberStyles.AllowThousands); i++)
+            for (int i = 0; i < 100_000; i++)
             {
                 foreach (var objectClass in objectClasses)
                 {


### PR DESCRIPTION
As `,` is a thousand separator (only) in (US) English or so, this test would fail in other localizations such as German with an exception while parsing.

AFAIK this is how you usually separate that in C# without having to resort to parsing static strings.