### PR TITLE
Change string.IsNullOrEmpty to new syntax

### DIFF
--- a/LinqToLdap/ConnectionFactoryBase.cs
+++ b/LinqToLdap/ConnectionFactoryBase.cs
@@ -1,4 +1,4 @@
-﻿using LinqToLdap.Logging;
+using LinqToLdap.Logging;
 using System;
 using System.DirectoryServices.Protocols;
 using System.Net;
@@ -41,7 +41,7 @@ namespace LinqToLdap
         /// <param name="serverName"></param>
         protected ConnectionFactoryBase(string serverName)
         {
-            if (serverName.IsNullOrEmpty()) throw new ArgumentNullException("serverName");
+            if (string.IsNullOrEmpty(serverName)) throw new ArgumentNullException("serverName");
 
             if (serverName.StartsWith("ldap://", StringComparison.OrdinalIgnoreCase))
             {

--- a/LinqToLdap/ConnectionFactoryBase.cs
+++ b/LinqToLdap/ConnectionFactoryBase.cs
@@ -41,7 +41,7 @@ namespace LinqToLdap
         /// <param name="serverName"></param>
         protected ConnectionFactoryBase(string serverName)
         {
-            if (string.IsNullOrEmpty(serverName)) throw new ArgumentNullException("serverName");
+            if (string.IsNullOrEmpty(serverName)) throw new ArgumentNullException(nameof(serverName));
 
             if (serverName.StartsWith("ldap://", StringComparison.OrdinalIgnoreCase))
             {


### PR DESCRIPTION
This will be problematic in .NET 6 or higher, as an argument is required and this is the new syntax. (Seems to work in your version, too.)

https://learn.microsoft.com/en-us/dotnet/api/system.string.isnullorempty?view=net-8.0