### PR TITLE
Use more reasonable exception and fix C# doc

### DIFF
--- a/LinqToLdap/LdapConfiguration.cs
+++ b/LinqToLdap/LdapConfiguration.cs
@@ -243,7 +243,7 @@ namespace LinqToLdap
         /// The server name can be an IP address, a DNS domain or host name.
         /// </param>
         /// <exception cref="ArgumentNullException">
-        /// THrown if <paramref name="serverName"/> is null, empty or white-space.
+        /// Thrown if <paramref name="serverName"/> is null, empty or white-space.
         /// </exception>
         public ILdapConnectionFactoryConfiguration ConfigureFactory(string serverName)
         {
@@ -264,7 +264,7 @@ namespace LinqToLdap
         /// The server name can be an IP address, a DNS domain or host name.
         /// </param>
         /// <exception cref="ArgumentNullException">
-        /// THrown if <paramref name="serverName"/> is null, empty or white-space.
+        /// Thrown if <paramref name="serverName"/> is null, empty or white-space.
         /// </exception>
         public IPooledConnectionFactoryConfiguration ConfigurePooledFactory(string serverName)
         {

--- a/LinqToLdap/LdapConfiguration.cs
+++ b/LinqToLdap/LdapConfiguration.cs
@@ -245,10 +245,11 @@ namespace LinqToLdap
         /// <exception cref="ArgumentNullException">
         /// Thrown if <paramref name="serverName"/> is null, empty or white-space.
         /// </exception>
+        /// <exception cref="InvalidOperationException"></exception>
         public ILdapConnectionFactoryConfiguration ConfigureFactory(string serverName)
         {
             if (ConnectionFactory != null)
-                throw new MappingException("A connection factory has already been configured.");
+                throw new InvalidOperationException("A connection factory has already been configured.");
 
             var factory = new LdapConnectionFactory(serverName) { Logger = Log };
 
@@ -266,10 +267,11 @@ namespace LinqToLdap
         /// <exception cref="ArgumentNullException">
         /// Thrown if <paramref name="serverName"/> is null, empty or white-space.
         /// </exception>
+        /// <exception cref="InvalidOperationException"></exception>
         public IPooledConnectionFactoryConfiguration ConfigurePooledFactory(string serverName)
         {
             if (ConnectionFactory != null)
-                throw new MappingException("A connection factory has already been configured.");
+                throw new InvalidOperationException("A connection factory has already been configured.");
 
             var factory = new PooledLdapConnectionFactory(serverName) { Logger = Log };
 
@@ -284,10 +286,11 @@ namespace LinqToLdap
         /// <param name="customFactory">The factory.</param>
         /// <typeparam name="T">Type of the factory</typeparam>
         /// <returns></returns>
+        /// <exception cref="InvalidOperationException"></exception>
         public T ConfigureCustomFactory<T>(T customFactory) where T : ILdapConnectionFactory
         {
             if (ConnectionFactory != null)
-                throw new MappingException("A connection factory has already been configured.");
+                throw new InvalidOperationException("A connection factory has already been configured.");
 
             ConnectionFactory = customFactory;
 

--- a/LinqToLdap/LdapConfiguration.cs
+++ b/LinqToLdap/LdapConfiguration.cs
@@ -301,12 +301,12 @@ namespace LinqToLdap
         /// Sets <see cref="Configuration"/> for global configuration access.
         /// </summary>
         /// <returns></returns>
-        /// <exception cref="MappingException">Throw if this method is called more than once.</exception>
+        /// <exception cref="InvalidOperationException">Throw if this method is called more than once.</exception>
         public LdapConfiguration UseStaticStorage()
         {
             if (Configuration != null)
             {
-                throw new MappingException("Static storage has already been set.");
+                throw new InvalidOperationException("Static storage has already been set.");
             }
             Configuration = this;
 


### PR DESCRIPTION
Breaking change, potentially!

InvalidOperationException fits better than both other exceptions.
Also, the C# doc did miss the immediate exception here.

IMHO the LDAP connection has nothing to do with mapping...

includes https://github.com/madhatter22/LinqToLdap/pull/39 (separated it just in case you did not want to merge it)